### PR TITLE
Fix Type mismatch for 'run.Config.influxdb'

### DIFF
--- a/templates/kapacitor.conf.j2
+++ b/templates/kapacitor.conf.j2
@@ -45,7 +45,7 @@ token = ""
   # Where to store the tasks database
   dir = "{{ kapacitor_task_dir }}"
 
-[influxdb]
+[[influxdb]]
   # Connect to an InfluxDB cluster
   # Kapacitor can subscribe, query and write to this cluster.
   # Using InfluxDB is not required and can be disabled.


### PR DESCRIPTION
Causes [run] 2016/04/27 00:19:55 E! parse config: Type mismatch for 'run.Config.influxdb': Expected slice but found 'map[string]interface {}'.
run: parse config: Type mismatch for 'run.Config.influxdb': Expected slice but found 'map[string]interface {}'.
