### PR TITLE
Ensure apt-transport-https is installed (fix debian jessie install)

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: Ensure apt-transport-https is installed.
+  apt: name=apt-transport-https state=present
+
 - name: Install any necessary dependencies [Debian/Ubuntu]
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
I needed that to have installation OK on debian jessie. Not tested on ubuntu.
